### PR TITLE
Não é possível criar eventos em dias que já passaram

### DIFF
--- a/app/Http/Controllers/EventoController.php
+++ b/app/Http/Controllers/EventoController.php
@@ -77,6 +77,14 @@ class EventoController extends Controller
 
         $ultimoEvento = \projetoGCA\Evento::where('grupoconsumo_id', '=', $grupoConsumo->id)->orderBy('id', 'DESC')->first();
         // return var_dump(empty($ultimoEvento));
+
+        $dataEvento = new DateTime($request->data_evento);
+        $dataAtual = new DateTime();
+        //return gettype($dataAtual);
+        if($dataEvento < $dataAtual){
+            return back()->withErrors(['data_evento' => 'Data do envento não pode ser anterior à data atual']);
+        }
+
         if(!is_null($ultimoEvento)){
             $dataUltimoEvento = new DateTime($ultimoEvento->data_evento);
             if($dataHoje < $dataUltimoEvento){

--- a/resources/views/evento/adicionarEvento.blade.php
+++ b/resources/views/evento/adicionarEvento.blade.php
@@ -4,6 +4,8 @@
     <a href="/home">Painel</a> > <a href="/gruposConsumo">Grupos de Consumo</a> > <a href="/gerenciar/{{$grupoConsumo->id}}">Gerenciar Grupo: {{$grupoConsumo->name}}</a> > Listar Eventos
 @endsection
 
+
+
 @section('content')
 <div class="container">
     <div class="row">


### PR DESCRIPTION
Não é mais permitido criar eventos cuja data seja anterior à do dia de criação do mesmo.