### PR TITLE
Correções no migration de Grupo de Consumo

### DIFF
--- a/database/migrations/2018_07_25_185340_create_grupo_consumos_table.php
+++ b/database/migrations/2018_07_25_185340_create_grupo_consumos_table.php
@@ -16,7 +16,7 @@ class CreateGrupoConsumosTable extends Migration
         Schema::create('grupo_consumos', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->string('descricao');
+            $table->string('descricao')->nullable();
             $table->string('periodo');
             $table->string('dia_semana');
             $table->integer('prazo_pedidos');


### PR DESCRIPTION
Correção para evitar erro ao deixar "descrição" em branco.